### PR TITLE
Support Embedding Strategy: Extend Vocab

### DIFF
--- a/scripts/lang_adapt/tokenized4clm_sampled.py
+++ b/scripts/lang_adapt/tokenized4clm_sampled.py
@@ -31,7 +31,6 @@ parser.add_argument('--tokenizer_dir', type=str, required=True)
 parser.add_argument('--hf_cache_dir', default="~/.cache/huggingface/transformers", type=str)
 parser.add_argument('--vocab_size', default=130_000, type=int)
 parser.add_argument('--extend_vocab', action='store_true')
-# parser.add_argument('--replace_with_overlap', action='store_true')
 parser.add_argument('--sample_size', default=None, type=int)
 parser.add_argument("--use_auth_token", default=False, action="store_true")
 
@@ -68,25 +67,16 @@ unique_toks = set()
 model_name = pathlib.Path(args.model).parts[-1]
 
 if args.extend_vocab:
-    # FIXME: needs to work on loading the original tokenizer.
-    tokenizer = AutoTokenizer.from_pretrained('/tmp-network/user/vnikouli/Projects/bigscience/multilingual-modeling/scripts/exp-009/tr5b-1B3-multilingual-alpha-checkpoints/')
+    # Yong: have checked that added tokens would have indices after the original vocab size.
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
     assert tokenizer.is_fast
     new_tokenizer = tokenizer.train_new_from_iterator(batch_iterator(), vocab_size=args.vocab_size)
     print("✅ Trained tokenizer with len ", len(new_tokenizer))
     added = tokenizer.add_tokens([tok for tok in new_tokenizer.vocab.keys()])
+    print([tok for tok in new_tokenizer.vocab.keys()])
     print(f"Overlap with previous vocab: {args.vocab_size - added}")
     tokenizer.save_pretrained(f"{args.tokenizer_dir}/tok_{model_name}_{lang}_oscar_{args.sample_size}samples_{args.vocab_size}vocab_extend")
     print(f"Saved tokenizer to {args.tokenizer_dir}/tok_{model_name}_{lang}_oscar_{args.sample_size}samples_{args.vocab_size}vocab_extend")
-
-# elif args.replace_with_overlap:
-#     # 
-#     tokenizer = AutoTokenizer.from_pretrained('/tmp-network/user/vnikouli/Projects/bigscience/multilingual-modeling/scripts/exp-009/tr5b-1B3-multilingual-alpha-checkpoints/', unk_token="<unk>")
-
-#     assert tokenizer.is_fast
-#     new_tokenizer = tokenizer.train_new_from_iterator(batch_iterator(), vocab_size=args.vocab_size)
-#     print("✅ Trained tokenizer with len ", len(new_tokenizer))
-#     new_tokenizer.save_pretrained(f"{args.tokenizer_dir}/{lang}_oscar_{args.sample_size}_tokenizer_{args.vocab_size}_overlap")
-#     print(f"Saved tokenizer to {args.tokenizer_dir}/{lang}_oscar_{args.sample_size}_tokenizer_{args.vocab_size}_overlap")
 
 else:
     tokenizer = AutoTokenizer.from_pretrained(args.model, use_auth_token=args.use_auth_token)


### PR DESCRIPTION
I have checked @vnikouliNLE's tokenization strategy and confirmed that the indices of added vocab tokens are after those of the original vocab.

I used [register hook](https://discuss.pytorch.org/t/update-only-sub-elements-of-weights/29101) to update subelements of the embedding weights.