### PR TITLE
[WIP] Refactor madx_run_clm.py

### DIFF
--- a/scripts/lang_adapt/madx_run_clm.py
+++ b/scripts/lang_adapt/madx_run_clm.py
@@ -433,11 +433,6 @@ def get_lm_dataset(training_args, data_args, model_args, tokenizer):
     return lm_datasets
 
 def modify_model(adapter_args, data_args, model_args, tokenizer, model):
-    #if "emb" in model_args.lang_adapt_strategies:
-    #    if "replace" in model_args.embedding_strategies:
-    #        for name, param in model.named_parameters():
-    #            if "wte" not in name and "wpe" not in name and "lm_head" not in name:
-    #                param.requires_grad = False
 
     def get_adapter_config(adapter_args, model_args):
         if adapter_args.adapter_config == "prefix_tuning":
@@ -566,16 +561,6 @@ def modify_model(adapter_args, data_args, model_args, tokenizer, model):
 
         embedding_layer.weight.register_hook(lambda grad: zero_grad(grad))
 
-    #if model_args.embedding_strategies == "overlap-replace":
-    #    if not tokenizer.name_or_path == model_args.model_name_or_path:
-    #        orig_tokenizer = AutoTokenizer.from_pretrained(model_args.model_name_or_path)
-    #    model.add_embeddings('lng_emb', tokenizer, reference_embedding='default', reference_tokenizer=orig_tokenizer )
-    #    model._active_embedding = "lng_emb"
-    #    model.delete_embeddings('default')
-    #    model.tie_weights()
-    #elif model_args.embedding_strategies == "replace":
-    #    model.resize_token_embeddings(len(tokenizer))
-
     trainable_params = 0
     frozen_params = 0
     emb_params = 0
@@ -688,9 +673,7 @@ def main():
     print("Model: 👇")
     print(model)
 
-    
-    # print("Embeddings at start of run:", model.get_input_embeddings().weight[250880:,:]) # get original weight for embedding layer
-    # orig_embeddings = model.get_input_embeddings().weight.detach().clone() # clone original weight for embedding layer
+
     # Training
     if training_args.do_train:
         checkpoint = None
@@ -725,17 +708,6 @@ def main():
         trainer.log_metrics("train", metrics)
         trainer.save_metrics("train", metrics)
         trainer.save_state()
-    
-    # uncomment to test whether extending vocab gradient masking is working correctly. 
-    # if model_args.embedding_strategies == "extend":
-    #     print("Unsliced, post-training:", model.get_input_embeddings().weight) # get updated weight
-    #     if not torch.equal(orig_embeddings[:250880, :], model.get_input_embeddings().weight[:250880, :]):
-    #         raise ValueError("embedding layer is updated where it shouldn't....")
-
-    #     if torch.equal(orig_embeddings[250880:, :], model.get_input_embeddings().weight[250880:, :]):
-    #         print("original embeddings:", orig_embeddings[250880:, :])
-    #         print("updated embeddings:", model.get_input_embeddings().weight[250880:, :])
-    #         raise ValueError("embedding layer is not updated where it should....")
 
 
     # Evaluation


### PR DESCRIPTION
Current changes: just some unused / commented out code from `madx_run_clm.py`. There is more, but I was not certain why certain parts are commented out.

We'll need to refactor the script as well once we add new ft strategies.

I also wonder whether it would be helpful to turn language experiments into a single packaged script (train tokenizer + adapt model + possibly run eval?) So that it is easier to onboard and have the others run experiments.