### PR TITLE
[WIP] Composable SFT

### DIFF
--- a/scripts/lang_adapt/efficient_ft/composable_sft/__init__.py
+++ b/scripts/lang_adapt/efficient_ft/composable_sft/__init__.py
@@ -1,0 +1,1 @@
+from .sft_args import SftArguments

--- a/scripts/lang_adapt/efficient_ft/composable_sft/sft_args.py
+++ b/scripts/lang_adapt/efficient_ft/composable_sft/sft_args.py
@@ -1,0 +1,116 @@
+from dataclasses import dataclass, field
+from typing import Optional
+# TODO: add attribution to Composable SFT authors/paper/code
+
+"""A modified version of the SftArguments class that drops unused args and changes default values for language adaptation."""
+
+@dataclass
+class SftArguments:
+    "Arguments pertaining to sparse fine-tuning configuration."""
+
+    train_sft: bool = field(
+        default=False, metadata={"help": "Whether to train sparse fine-tuning."}
+    ) # newly added
+    
+    lang_ft: Optional[str] = field(
+        default=None, metadata={"help": "Path to saved language SparseFineTuning."}
+    )
+    task_ft: Optional[str] = field(
+        default=None, metadata={"help": "Path to saved task SparseFineTuning."}
+    )
+    
+    sparse_ft_method: Optional[str] = field(
+        default='LotteryTicket',
+        metadata={"help": 'Sparse fine-tuning method. Can be LotteryTicket or Random.'},
+    )
+
+    full_l1_reg: Optional[float] = field(
+        default=0.1, metadata={"help": "Coefficient of L1 regularisation during full fine-tuning."}
+    ) # changed from 0.0 to 0.1
+    sparse_l1_reg: Optional[float] = field(
+        default=0.1, metadata={"help": "Coefficient of L1 regularisation during sparse fine-tuning."}
+    ) # changed from 0.0 to 0.1
+    apply_reg_to_sparse_only: bool = field(
+        default=False,
+        metadata={
+            "help": "If true, only applies regularisation to those parameters which are eligible for sparse fine-tuning."
+        },
+    )
+
+    freeze_embeddings: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to freeze embeddings."
+        },
+    )
+    freeze_head: bool = field(
+        default=False,
+        metadata={"help": "Whether to freeze language modeling head."},
+    )
+    untie_embeddings: bool = field(
+        default=False,
+        metadata={"help": "Whether to untie input and output embeddings."},
+    )
+    freeze_decoder: bool = field(
+        default=False,
+        metadata={"help": "Whether to freeze only output embeddings."},
+    )
+    freeze_layer_norm: bool = field(
+        default=True,
+        metadata={"help": "Whether to freeze layer normalisation parameters."},
+    ) # changed from False to True
+    
+    ft_params_proportion: Optional[float] = field(
+        default=0.01,
+        metadata={
+            "help": "The proportion of model parameters for which to learn non-zero differences during fine-tuning."
+        },
+    )
+    ft_params_num: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": "The number of model parameters for which to learn non-zero differences during fine-tuning."
+        },
+    )
+    n_ft_iterations: Optional[int] = field(
+        default=5,
+        metadata={
+            "help": "The number of parameter selection iterations during fine-tuning."
+        },
+    )
+    full_ft_min_steps_per_iteration: Optional[int] = field(
+        default=10,
+        metadata={
+            "help": "Minimum number of steps per parameter selection iteration during full fine-tuning."
+        },
+    )
+    sparse_ft_min_steps_per_iteration: Optional[int] = field(
+        default=10,
+        metadata={
+            "help": "Minimum of steps per parameter selection iteration during sparse fine-tuning."
+        },
+    )
+    full_ft_max_steps_per_iteration: Optional[int] = field(
+        default=100,
+        metadata={
+            "help": "Maximum number of steps per parameter selection iteration during full fine-tuning."
+        },
+    )
+    sparse_ft_max_steps_per_iteration: Optional[int] = field(
+        default=100,
+        metadata={
+            "help": "Maximum of steps per parameter selection iteration during sparse fine-tuning."
+        },
+    )
+    full_ft_max_epochs_per_iteration: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": "Maximum number of epochs per parameter selection iteration during full fine-tuning."
+        },
+    )
+    sparse_ft_max_epochs_per_iteration: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": "Maximum number of epochs per parameter selection iteration during sparse fine-tuning."
+        },
+    )

--- a/scripts/lang_adapt/run_clm_sft.sh
+++ b/scripts/lang_adapt/run_clm_sft.sh
@@ -1,0 +1,64 @@
+# axis
+LANG="th"
+MAX_TRAIN_SAMPLES=100000
+BIGS_MODEL="bigscience/bloom-350m"
+ADPT_REDUCTION_FACTOR=16
+ADPT_STRATEGY="emb-and-sft"
+EMB_STRATEGY="extend"
+
+tokenizer_dir=./tokenizers/tok_bloom-350m_th_oscar_10000samples_5000vocab_extend/
+cache_dir="./cache"
+output_dir="./sft_testing"
+logging_dir="./sft_testing"
+mkdir -p $output_dir
+mkdir -p $logging_dir
+
+CUDA_VISIBLE_DEVICES=4 python madx_run_clm.py \
+    --seed 0 \
+    --fp16 \
+    --model_name_or_path $BIGS_MODEL \
+    --tokenizer_name $tokenizer_dir \
+    --dataset_name oscar \
+    --dataset_config_name "unshuffled_deduplicated_$LANG" \
+    --cache_dir $cache_dir \
+    --logging_dir $logging_dir \
+    --report_to "tensorboard" \
+    --learning_rate 0.001 \
+    --do_train \
+    --do_eval \
+    --train_sft \
+    --load_best_model_at_end \
+    --output_dir $output_dir \
+    --preprocessing_num_workers 8 \
+    --overwrite_output_dir \
+    --per_device_train_batch_size 1 \
+    --gradient_accumulation_steps 8 \
+    --per_device_eval_batch_size 1 \
+    --eval_accumulation_steps 8 \
+    --eval_steps 1000 \
+    --evaluation_strategy "steps" \
+    --max_eval_samples 5000 \
+    --logging_steps 100 \
+    --save_steps 5000 \
+    --save_strategy "steps" \
+    --max_train_samples $MAX_TRAIN_SAMPLES \
+    --max_steps 50000 \
+    --lang_adapt_strategies "$ADPT_STRATEGY" \
+    --embedding_strategies "$EMB_STRATEGY" \
+    --adapter_reduction_factor $ADPT_REDUCTION_FACTOR \
+    --language $LANG \
+    --full_ft_min_steps_per_iteration 10000 \
+    --sparse_ft_min_steps_per_iteration 10000 \
+    --full_ft_max_steps_per_iteration 10000 \
+    --sparse_ft_max_steps_per_iteration 10000 \
+    --n_ft_iterations 5 \
+    # --full_ft_max_epochs_per_iteration 100 \
+    # --sparse_ft_max_epochs_per_iteration 100 \
+    
+# export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda-11.1/lib64
+# export PATH=$PATH:/usr/local/cuda-11.1/bin
+# export CUDA_HOME=/usr/local/cuda-11.1
+
+
+
+


### PR DESCRIPTION
https://arxiv.org/pdf/2110.07560.pdf <-- Paper
https://github.com/cambridgeltl/composable-sft <-- code

Their code is very well packaged, so it wasn't too hard to add 

The file `sft_args` is essentially their `SftArguments` class, but I've made some of the defaults closer to the lang adaptation in their paper/what we should use.

TODOs:
- make sure that logging loss works correctly. At the moment, the code from the paper seems to not log loss correctly, so I may need to edit their code to fix it here.
- Make it easier for the user to just swap `--train_adapter` and `--lang_adapt_strategy` out for `--train_sft`. This means manually overriding some parts of sft_args in the script with model_args.
- Determine hyperparameters we should use for comparable testing. This will mean, likely, 50k train steps + 50k rewinded steps with one iteration in their method. Or maybe 5 iterations + 10k train steps twice? Idk yet
- Add a computation for converting between their "K parameters to tune" vs. number of total parameters in adapters. Can hard-code a formula for this, I don't want to mess with adding then removing an adapter


If we want to train *both adapters and Composable SFT* at once, this will require some extra code. Probably not TOO bad, but would need extra testing to account for freezing all correct parameters
